### PR TITLE
use bowery/linguist instead of github/linguist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 DEPS = $(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
 all: deps format
-	@go get -d
 	@go build
 	./mercer
 
 deps:
 	@echo "--> Installing build dependencies"
+	@cd classifiers && bundle install
 	@go get -d -v ./...
 	@echo $(DEPS) | xargs -n1 go get -d
 

--- a/classifiers/Gemfile
+++ b/classifiers/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'github-linguist', '~> 3.5.2'
+gem 'github-linguist', git: 'https://github.com/Bowery/linguist'
 gem 'rugged', '~> 0.21.0'

--- a/classifiers/Gemfile.lock
+++ b/classifiers/Gemfile.lock
@@ -1,25 +1,24 @@
+GIT
+  remote: https://github.com/Bowery/linguist
+  revision: 85c3c381022342a768ede033dab412fe55921537
+  specs:
+    github-linguist (4.0.0)
+      charlock_holmes (~> 0.7.3)
+      escape_utils (~> 1.0.1)
+      mime-types (~> 1.19)
+      rugged (~> 0.21.1b2)
+
 GEM
   remote: https://rubygems.org/
   specs:
     charlock_holmes (0.7.3)
     escape_utils (1.0.1)
-    github-linguist (3.5.2)
-      charlock_holmes (~> 0.7.3)
-      escape_utils (~> 1.0.1)
-      mime-types (~> 1.19)
-      pygments.rb (~> 0.6.0)
-      rugged (~> 0.21.1b2)
     mime-types (1.25.1)
-    posix-spawn (0.3.9)
-    pygments.rb (0.6.0)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.1.0)
     rugged (0.21.1b2)
-    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-linguist (~> 3.5.2)
+  github-linguist!
   rugged (~> 0.21.0)

--- a/routes.go
+++ b/routes.go
@@ -101,15 +101,16 @@ func AnalyzeCodeHandler(rw http.ResponseWriter, req *http.Request) {
 
 	cmds := &Commands{}
 	for language, weight := range languages {
-		lc := LanguageToCommands[language]
-		if lc == nil {
-			fmt.Println(language, "is not currently supported")
-			break
-		}
 		fmt.Println(language, "-", weight)
-		cmds.Start += lc.Start + "\n"
-		cmds.Build += lc.Build + "\n"
-		cmds.Init += lc.Init + "\n"
+		lc := LanguageToCommands[language]
+		if lc != nil {
+			cmds.Start += lc.Start + "\n"
+			cmds.Build += lc.Build + "\n"
+			cmds.Init += lc.Init + "\n"
+		} else {
+			fmt.Println(language, "is not currently supported")
+		}
+
 	}
 
 	renderer.JSON(rw, http.StatusOK, map[string]interface{}{


### PR DESCRIPTION
Salut @sjkaliski,

Please review the following commits I made in branch 'thebyrd-use-bowery-linguist'. closes issue #1.

5c5b426f6377dd1e66fa88909be1a5f42521f563 (2014-11-16 20:00:17 -0500)
use bowery/linguist instead of github/linguist

R=@sjkaliski
